### PR TITLE
Fix/upgradechekbypass

### DIFF
--- a/13_activate/index.md
+++ b/13_activate/index.md
@@ -74,7 +74,10 @@ https://www.ibm.com/docs/en/maximo-manage/8.3.0?topic=suite-deployment-overview
 
 * (英語以外の言語を使用する場合)Db2 Vargraphicをチェックする
 
-* アップグレードバージョンチェックをバイパス: このアクティブ化が初回の場合チェック不要
+* アップグレードバージョンチェックをバイパス: 通常はチェック不要。データベースへのネットワーク接続などが原因でアクティブ化が失敗した際のトラブルシューティングで利用する場合がある。詳細は以下参照。
+  
+  参考.Troubleshooting database deployment
+  https://www.ibm.com/docs/en/maximo-manage/8.3.0?topic=database-troubleshooting-deployment
 </InlineNotification>
 
 ![](2022-04-03-14-38-13.png)

--- a/13_activate/index.md
+++ b/13_activate/index.md
@@ -77,7 +77,7 @@ https://www.ibm.com/docs/en/maximo-manage/8.3.0?topic=suite-deployment-overview
 * アップグレードバージョンチェックをバイパス: このアクティブ化が初回の場合チェック不要
 </InlineNotification>
 
-	![](2022-04-03-14-38-13.png)
+![](2022-04-03-14-38-13.png)
 
 
 ### 5.追加言語

--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ Ansibleのスキルをお持ちの方は以下を利用してMASのインスト�
 * その他リンク集
 
 	https://ibm.box.com/s/82ypn8va3yi37sz8jw1c01vmh2vcwmgt
-	
+
+* 参考サイト
+  
+    Maximo Programming
+
+	https://maximopro.tumblr.com/
+
 	### 次項
   [01_事前準備](../main/01_prereqs/index.md)


### PR DESCRIPTION
アップグレードバージョンチェックをバイパスの記述を修正。

`アップグレードバージョンチェックをバイパス: 通常はチェック不要。データベースへのネットワーク接続などが原因でアクティブ化が失敗した際のトラブルシューティングで利用する場合がある。詳細は以下参照。`